### PR TITLE
Coordinate arrays

### DIFF
--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -111,7 +111,7 @@ class NCDataModel(object):
         # We've now classified this NC file.
         self._classified = True
 
-    def get_chunks(self, data_var_name):
+    def get_chunks(self, data_var_name, max_contiguous_dims=3):
         """
         Get chunks for a named data variable `data_var_name`.
 
@@ -128,7 +128,6 @@ class NCDataModel(object):
         if chunks == 'contiguous':
             shape = data_var.shape
             data_ndim = len(shape)
-            max_contiguous_dims = 3
             overflow_dims = data_ndim - max_contiguous_dims
             if data_ndim > max_contiguous_dims:
                 # More than 3D so chunk along outer (leading) dimension

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -60,7 +60,9 @@ class TDBWriter(Writer):
     """
     def __init__(self, data_model, array_filepath,
                  array_name=None, unlimited_dims=None):
-        super().__init__(data_model, filepath, array_name, unlimited_dims)
+        super().__init__(data_model, array_filepath, array_name, unlimited_dims)
+        if self.unlimited_dims is None:
+            self.unlimited_dims = []
 
     def _public_domain_name(self, domain):
         domain_index = self.data_model.domains.index(domain)
@@ -193,7 +195,7 @@ class TDBWriter(Writer):
 
             # Create group.
             domain_name = self._public_domain_name(domain)
-            group_dirname = os.path.join(self.tiledb_filepath, self.array_name, domain_name)
+            group_dirname = os.path.join(self.array_filepath, self.array_name, domain_name)
             # TODO: why is this necessary? Shouldn't tiledb create if this dir does not exist?
             self._create_tdb_directory(group_dirname)
             tiledb.group_create(group_dirname)


### PR DESCRIPTION
Write dimension-describing coordinates as TileDB arrays. This enables spatial indexing of data variables (via extra code), and preserves more of the NetCDF metadata (essential for reading the contents of TileDB arrays back into Xarray or Iris).