### PR TITLE
Multi-attr TileDB arrays 

### DIFF
--- a/nctotdb/__init__.py
+++ b/nctotdb/__init__.py
@@ -1,3 +1,3 @@
 from .data_model import NCDataModel
 from .readers import TDBReader, ZarrReader
-from .writers import TDBWriter, ZarrWriter
+from .writers import MultiAttrTDBWriter, TDBWriter, ZarrWriter

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -258,7 +258,7 @@ class TDBWriter(Writer):
         domain_path = os.path.join(self.array_filepath, self.array_name, domain_name)
 
         # For multidim / multi-attr appends this will be more complex.
-        common_job_args = [var_name, domain_path, append_axis, append_dim,
+        common_job_args = [domain_path, var_name, append_axis, append_dim,
                            self_ind_stop, self_dim_stop, self_step,
                            make_data_model, verbose]
         job_args = [[other] + common_job_args for other in others]
@@ -289,10 +289,21 @@ class MultiAttrTDBWriter(TDBWriter):
 
     """
     def __init__(self, data_model, array_filepath,
-                 array_name=None, unlimited_dims=None):
+                 array_name=None, unlimited_dims=None, domain_separator=','):
         super().__init__(data_model, array_filepath, array_name, unlimited_dims)
 
-        self.domains_mapping = None
+        self.domain_separator = domain_separator
+        self._domains_mapping = None
+
+    @property
+    def domains_mapping(self):
+        if self._domains_mapping is None:
+            self._make_shape_domains()
+        return self._domains_mapping
+
+    @domains_mapping.setter
+    def domains_mapping(self, value):
+        self._domains_mapping = value
 
     def _public_domain_name(self, dimensions, separator):
         """
@@ -322,7 +333,14 @@ class MultiAttrTDBWriter(TDBWriter):
                     metadata[f'{key}__{var_name}'] = value
         return metadata
 
-    def _make_shape_domains(self, domain_separator):
+    def _get_array_attrs(self, array_path):
+        # Duplicated from `readers.TDBReader`.
+        with tiledb.open(array_path, "r") as A:
+            nattr = A.schema.nattr
+            attr_names = [A.schema.attr(i).name for i in range(nattr)]
+        return attr_names
+
+    def _make_shape_domains(self):
         """
         Make one domain for each unique combination of shape and dimension variables.
 
@@ -334,7 +352,7 @@ class MultiAttrTDBWriter(TDBWriter):
         shape_domains = []
         for data_var_name in self.data_model.data_var_names:
             dimensions = self.data_model.variables[data_var_name].dimensions
-            domain_string = self._public_domain_name(dimensions, domain_separator)
+            domain_string = self._public_domain_name(dimensions, self.domain_separator)
             shape_domains.append((domain_string, data_var_name))
 
         domains_mapping = defaultdict(list)
@@ -385,7 +403,7 @@ class MultiAttrTDBWriter(TDBWriter):
         schema = tiledb.ArraySchema(domain=tdb_domain, sparse=False, attrs=attrs)
         tiledb.Array.create(array_filename, schema)
 
-    def create_domains(self, data_array_name='data', domain_sep=','):
+    def create_domains(self, data_array_name='data'):
         """
         Create one TileDB domain for each unique shape / dimensions combination
         in the input Data Model. Each domain will contain:
@@ -395,10 +413,10 @@ class MultiAttrTDBWriter(TDBWriter):
             combination of dimensions.
 
         """
-        self._make_shape_domains(domain_sep)
+        self._make_shape_domains(self.domain_separator)
         
         for domain_name, domain_var_names in self.domains_mapping.items():
-            domain_coord_names = domain_name.split(domain_sep)
+            domain_coord_names = domain_name.split(self.domain_separator)
 
             # Create group.
             group_dirname = os.path.join(self.array_filepath, self.array_name, domain_name)
@@ -415,6 +433,80 @@ class MultiAttrTDBWriter(TDBWriter):
             self.create_multiattr_array(domain_var_names, domain_coord_names,
                                         group_dirname, data_array_name)
             self.populate_multiattr_array(data_array_name, domain_var_names, group_dirname)
+
+    def _make_tile_helper(self, args):
+        other, domain_names, data_array_name, append_dim, *other_args = args
+
+        other_data_model = NCDataModel(other)
+        other_data_model.classify_variables()
+        other_data_model.get_metadata()
+
+        for domain_name in domain_names:
+            append_axis = domain_name.split(self.domain_separator).index(append_dim)
+            domain_path = os.path.join(self.array_filepath, self.array_name, domain_name)
+            array_var_names = self._get_array_attrs(os.path.join(domain_path, data_array_name))
+            _make_multiattr_tile(other_data_model, domain_path, data_array_name,
+                                 array_var_names, *other_args)
+
+    def append(self, others, append_dim, data_array_name,
+              logfile=None, parallel=False, verbose=False):
+        """
+        Append extra data as described by the contents of `others` onto
+        an existing TileDB array along the axis defined by `append_dim`.
+
+        Notes:
+          * extends one dimension only
+          * cannot create new dimensions, only extend existing dimensions
+
+        TODO support multiple axis appends.
+        TODO check if there's already data at the write inds and add an overwrite?
+
+        """
+        if logfile is not None:
+            logging.basicConfig(filename=logfile,
+                                level=logging.DEBUG,
+                                format='%(asctime)s %(message)s',
+                                datefmt='%d/%m/%Y %H:%M:%S')
+
+        make_data_model = False
+        # Check what sort of thing `others` is.
+        if isinstance(others, NCDataModel):
+            others = [others]
+        elif isinstance(others, str):
+            others = [others]
+
+        # Check all domains for including the append dimension.
+        domain_names = [d for d in self.domains_mapping.keys()
+                        if append_dim in d.split(self.domain_separator)]
+
+        # Get starting dimension points and offsets.
+        self_dim_var = self.data_model.variables[append_dim]
+        self_dim_points = copy.copy(self_dim_var[:])
+        self_dim_start, self_dim_stop, self_step = _dim_points(self_dim_points)
+        self_ind_start, self_ind_stop = _dim_inds(self_dim_points,
+                                                  [self_dim_start, self_dim_stop])
+
+        # For multidim / multi-attr appends this will be more complex.
+        common_job_args = [domain_names, data_array_name, append_dim,
+                           self_ind_stop, self_dim_stop, self_step]
+        job_args = [[other] + common_job_args for other in others]
+
+        if parallel:
+            # import dask.bag as db
+            # bag_of_jobs = db.from_sequence(job_args)
+            # bag_of_jobs.map(_make_tile_helper).compute()
+            raise NotImplementedError
+        else:
+            for i, args in enumerate(job_args):
+                # args += [i, len(job_args)]
+                self._make_tile_helper(args)
+
+        if len(others) > 10:
+            # Consolidate at the end of the append operations to make the resultant
+            # array more performant.
+            config = tiledb.Config({"sm.consolidation.steps": 1000})
+            ctx = tiledb.Ctx(config)
+            tiledb.consolidate(os.path.join(domain_path, var_name), ctx=ctx)
 
 
 class ZarrWriter(Writer):
@@ -609,7 +701,44 @@ def _make_tile_helper(args):
     _make_tile(*args)
 
 
-def _make_tile(other, var_name, domain_path, append_axis, append_dim,
+def _make_multiattr_tile(other_data_model, domain_path, data_array_name,
+                         var_names, append_axis, append_dim,
+                         self_ind_stop, self_dim_stop, self_step):
+    """Process appending a single tile to `self`, per domain."""
+    other_data_vars = [other_data_model.variables[var_name] for var_name in var_names]
+    other_dim_var = other_data_model.variables[append_dim]
+    other_dim_points = np.atleast_1d(other_dim_var[:])
+
+    # Check for the dataset being scalar on the append dimension.
+    scalar_coord = False
+    if len(other_dim_points) == 1:
+        scalar_coord = True
+
+    if scalar_coord:
+        shape = [1] + list(other_data_var.shape)
+    else:
+        shape = other_data_var.shape
+
+    offsets = []
+    try:
+        offset = _dim_offsets(
+            other_dim_points, self_ind_stop, self_dim_stop, self_step,
+            scalar=scalar_coord)
+        offsets = [0] * len(shape)
+        offsets[append_axis] = offset
+        offset_inds = _array_indices(shape, offsets)
+    except Exception as e:
+        logging.info(f'{other_data_model.netcdf_filename} - {e}')
+
+    # Append the data from other.
+    data_array_path = os.path.join(domain_path, data_array_name)
+    write_multiattr_array(data_array_path, other_data_vars, start_index=offset_inds)
+    # Append the extra dimension points from other.
+    dim_array_path = os.path.join(domain_path, append_dim)
+    write_array(dim_array_path, other_dim_var, start_index=offset_inds[append_axis])
+
+
+def _make_tile(other, domain_path, var_name, append_axis, append_dim,
                self_ind_stop, self_dim_stop, self_step,
                make_data_model, verbose, i=None, num=None):
     """Process appending a single tile to `self`."""


### PR DESCRIPTION
Add a new TileDB writer that can write multiple, identically-shaped data variables into the same, multi-attribute, TileDB array.

Not done yet:
* [x] multi-attr append (#17)
* [x] multi-attr read to Iris (#18)
 
Proposes a solution (with a very different API!) to #9.