### PR TITLE
Fill missing append coordinate points

### DIFF
--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -511,7 +511,13 @@ class MultiAttrTDBWriter(TDBWriter):
             # array more performant.
             config = tiledb.Config({"sm.consolidation.steps": 1000})
             ctx = tiledb.Ctx(config)
-            tiledb.consolidate(os.path.join(domain_path, var_name), ctx=ctx)
+            for i, domain_name in enumerate(domain_names):
+                if verbose:
+                    print()  # Clear last carriage-returned print statement.
+                    print(f'Consolidating array: {i}/{len(domain_names)}', end='\r')
+                array_path = os.path.join(self.array_filepath, self.array_name,
+                                          domain_name, data_array_name)
+                tiledb.consolidate(array_path, ctx=ctx)
 
 
 class ZarrWriter(Writer):

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -406,7 +406,7 @@ class MultiAttrTDBWriter(TDBWriter):
             combination of dimensions.
 
         """
-        self._make_shape_domains(self.domain_separator)
+        self._make_shape_domains()
         
         for domain_name, domain_var_names in self.domains_mapping.items():
             domain_coord_names = domain_name.split(self.domain_separator)


### PR DESCRIPTION
When appending a lot of content along the append dimension it is not unreasonable to consider that there may well be missing data at various indexes of the append dimension - because of missing data, missing files, or something else. 

Currently these missing indices are represented as NaN in both the data and the coordinate points, which is appropriate for the data points (the data is missing after all), but not so much for the append coordinate points. We know what the missing append coordinate values should be, as the append dimension must be monotonic, so we should interpolate and fill the missing coordinate points so that the dataset can be loaded using Iris (and it's metadata-appropriate: we know what the values _should_ be; we just don't have any record of them because they're missing).