### PR TITLE
Pass grid mapping metadata

### DIFF
--- a/nctotdb/__init__.py
+++ b/nctotdb/__init__.py
@@ -1,3 +1,4 @@
 from .data_model import NCDataModel
+from .grid_mappings import GridMapping, store_grid_mapping
 from .readers import TDBReader, ZarrReader
 from .writers import MultiAttrTDBWriter, TDBWriter, ZarrWriter

--- a/nctotdb/grid_mappings.py
+++ b/nctotdb/grid_mappings.py
@@ -1,0 +1,146 @@
+import json
+
+import iris.coord_systems
+
+
+def store_grid_mapping(grid_mapping_variable):
+    """Store the metadata for a NetCDF grid mapping variable as a JSON string."""
+    ncattrs = grid_mapping_variable.ncattrs()
+    return json.dumps({k: grid_mapping_variable.getncattr(k) for k in ncattrs})
+
+
+# Taken from https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/_pyke_rules/fc_rules_cf.krb.
+class GridMapping(object):
+    """
+    Convert a NetCDF grid mapping variable (expressed as a JSON string) into an
+    Iris coordinate system.
+
+    """
+    # Grid mapping names.
+    GRID_MAPPING_ALBERS = 'albers_conical_equal_area'
+    GRID_MAPPING_AZIMUTHAL = 'azimuthal_equidistant'
+    GRID_MAPPING_LAMBERT_AZIMUTHAL = 'lambert_azimuthal_equal_area'
+    GRID_MAPPING_LAMBERT_CONFORMAL = 'lambert_conformal_conic'
+    GRID_MAPPING_LAMBERT_CYLINDRICAL = 'lambert_cylindrical_equal_area'
+    GRID_MAPPING_LAT_LON = 'latitude_longitude'
+    GRID_MAPPING_MERCATOR = 'mercator'
+    GRID_MAPPING_ORTHO = 'orthographic'
+    GRID_MAPPING_POLAR = 'polar_stereographic'
+    GRID_MAPPING_ROTATED_LAT_LON = 'rotated_latitude_longitude'
+    GRID_MAPPING_STEREO = 'stereographic'
+    GRID_MAPPING_TRANSVERSE = 'transverse_mercator'
+    GRID_MAPPING_VERTICAL = 'vertical_perspective'
+
+    # Earth grid attributes.
+    SEMI_MAJOR_AXIS = 'semi_major_axis'
+    SEMI_MINOR_AXIS = 'semi_minor_axis'
+    INVERSE_FLATTENING = 'inverse_flattening'
+    EARTH_RADIUS = 'earth_radius'
+    LON_OF_PROJ_ORIGIN = 'longitude_of_projection_origin'
+    NORTH_POLE_LAT = 'grid_north_pole_latitude'
+    NORTH_POLE_LON = 'grid_north_pole_longitude'
+    NORTH_POLE_GRID_LON = 'north_pole_grid_longitude'
+
+    def __init__(self, grid_mapping_string):
+        self.grid_mapping_string = grid_mapping_string
+        self.grid_mapping = json.loads(self.grid_mapping_string)
+
+    def _get_ellipsoid(self):
+        """Return the ellipsoid definition."""
+        major = self.grid_mapping.get(SEMI_MAJOR_AXIS, None)
+        minor = self.grid_mapping.get(SEMI_MINOR_AXIS, None)
+        inverse_flattening = self.grid_mapping.get(INVERSE_FLATTENING, None)
+
+        if major is not None and minor is not None:
+            inverse_flattening = None
+        if major is None and minor is None and inverse_flattening is None:
+            major = self.grid_mapping.get(EARTH_RADIUS, None) 
+
+        return major, minor, inverse_flattening
+
+    def build_coordinate_system(self):
+        """Create a coordinate system from the grid mapping variable."""
+        major, minor, inverse_flattening = self._get_ellipsoid()
+        return iris.coord_systems.GeogCS(major, minor, inverse_flattening)
+
+    def build_rotated_coordinate_system(self):
+        """Create a rotated coordinate system from the grid mapping variable."""
+        major, minor, inverse_flattening = self._get_ellipsoid()
+        
+        north_pole_latitude = self.grid_mapping.get(NORTH_POLE_LAT, 90.0)
+        north_pole_longitude = self.grid_mapping.get(NORTH_POLE_LON, 0.0)
+        north_pole_grid_lon = self.grid_mapping.get(NORTH_POLE_GRID_LON, 0.0)
+        
+        ellipsoid = None
+        if major is not None or minor is not None or inverse_flattening is not None:
+            ellipsoid = iris.coord_systems.GeogCS(major, minor, inverse_flattening)
+
+        return iris.coord_systems.RotatedGeogCS(north_pole_latitude, north_pole_longitude,
+                                                north_pole_grid_lon, ellipsoid)
+
+    def build_mercator_coordinate_system(self):
+        """Create a Mercator coordinate system from the grid mapping variable."""
+        major, minor, inverse_flattening = self._get_ellipsoid()
+        longitude_of_projection_origin = self.grid_mapping.get(LON_OF_PROJ_ORIGIN, None)
+
+        ellipsoid = None
+        if major is not None or minor is not None or inverse_flattening is not None:
+            ellipsoid = iris.coord_systems.GeogCS(major, minor, inverse_flattening)
+
+        return iris.coord_systems.Mercator(longitude_of_projection_origin, ellipsoid=ellipsoid)
+
+    def get_grid_mapping(self):
+        """
+        Determine the type of grid mapping variable we have and call the
+        appropriate converter.
+
+        Note that we do not support translation of all grid mapping variables.
+        Only the following are supported:
+          * latitude_longitude
+          * mercator
+          * rotated_latitude_longitude
+        
+        """
+        grid_mapping_name = self.grid_mapping.get('grid_mapping_name').lower()
+
+        if grid_mapping_name == GRID_MAPPING_LAT_LON:
+            result = self.build_coordinate_system()
+        elif grid_mapping_name == GRID_MAPPING_ROTATED_LAT_LON:
+            result = self.build_rotated_coordinate_system()
+        elif grid_mapping_name == GRID_MAPPING_MERCATOR:
+            result = self.build_mercator_coordinate_system()
+        elif grid_mapping_name == GRID_MAPPING_ALBERS:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_AZIMUTHAL:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_LAMBERT_AZIMUTHAL:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_LAMBERT_CONFORMAL:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_LAMBERT_CYLINDRICAL:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_ORTHO:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_POLAR:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_STEREO:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_TRANSVERSE:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        elif grid_mapping_name == GRID_MAPPING_VERTICAL:
+            # Grid mapping type not handled yet.
+            raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
+        else:
+            # Not a valid grid mapping name.
+            raise ValueError(f'{grid_mapping_name!r} is not a valid grid mapping name.')
+
+        return result

--- a/nctotdb/grid_mappings.py
+++ b/nctotdb/grid_mappings.py
@@ -47,14 +47,14 @@ class GridMapping(object):
 
     def _get_ellipsoid(self):
         """Return the ellipsoid definition."""
-        major = self.grid_mapping.get(SEMI_MAJOR_AXIS, None)
-        minor = self.grid_mapping.get(SEMI_MINOR_AXIS, None)
-        inverse_flattening = self.grid_mapping.get(INVERSE_FLATTENING, None)
+        major = self.grid_mapping.get(self.SEMI_MAJOR_AXIS, None)
+        minor = self.grid_mapping.get(self.SEMI_MINOR_AXIS, None)
+        inverse_flattening = self.grid_mapping.get(self.INVERSE_FLATTENING, None)
 
         if major is not None and minor is not None:
             inverse_flattening = None
         if major is None and minor is None and inverse_flattening is None:
-            major = self.grid_mapping.get(EARTH_RADIUS, None) 
+            major = self.grid_mapping.get(self.EARTH_RADIUS, None)
 
         return major, minor, inverse_flattening
 
@@ -67,9 +67,9 @@ class GridMapping(object):
         """Create a rotated coordinate system from the grid mapping variable."""
         major, minor, inverse_flattening = self._get_ellipsoid()
         
-        north_pole_latitude = self.grid_mapping.get(NORTH_POLE_LAT, 90.0)
-        north_pole_longitude = self.grid_mapping.get(NORTH_POLE_LON, 0.0)
-        north_pole_grid_lon = self.grid_mapping.get(NORTH_POLE_GRID_LON, 0.0)
+        north_pole_latitude = self.grid_mapping.get(self.NORTH_POLE_LAT, 90.0)
+        north_pole_longitude = self.grid_mapping.get(self.NORTH_POLE_LON, 0.0)
+        north_pole_grid_lon = self.grid_mapping.get(self.NORTH_POLE_GRID_LON, 0.0)
         
         ellipsoid = None
         if major is not None or minor is not None or inverse_flattening is not None:
@@ -81,7 +81,7 @@ class GridMapping(object):
     def build_mercator_coordinate_system(self):
         """Create a Mercator coordinate system from the grid mapping variable."""
         major, minor, inverse_flattening = self._get_ellipsoid()
-        longitude_of_projection_origin = self.grid_mapping.get(LON_OF_PROJ_ORIGIN, None)
+        longitude_of_projection_origin = self.grid_mapping.get(self.LON_OF_PROJ_ORIGIN, None)
 
         ellipsoid = None
         if major is not None or minor is not None or inverse_flattening is not None:
@@ -103,40 +103,40 @@ class GridMapping(object):
         """
         grid_mapping_name = self.grid_mapping.get('grid_mapping_name').lower()
 
-        if grid_mapping_name == GRID_MAPPING_LAT_LON:
+        if grid_mapping_name == self.GRID_MAPPING_LAT_LON:
             result = self.build_coordinate_system()
-        elif grid_mapping_name == GRID_MAPPING_ROTATED_LAT_LON:
+        elif grid_mapping_name == self.GRID_MAPPING_ROTATED_LAT_LON:
             result = self.build_rotated_coordinate_system()
-        elif grid_mapping_name == GRID_MAPPING_MERCATOR:
+        elif grid_mapping_name == self.GRID_MAPPING_MERCATOR:
             result = self.build_mercator_coordinate_system()
-        elif grid_mapping_name == GRID_MAPPING_ALBERS:
+        elif grid_mapping_name == self.GRID_MAPPING_ALBERS:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_AZIMUTHAL:
+        elif grid_mapping_name == self.GRID_MAPPING_AZIMUTHAL:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_LAMBERT_AZIMUTHAL:
+        elif grid_mapping_name == self.GRID_MAPPING_LAMBERT_AZIMUTHAL:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_LAMBERT_CONFORMAL:
+        elif grid_mapping_name == self.GRID_MAPPING_LAMBERT_CONFORMAL:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_LAMBERT_CYLINDRICAL:
+        elif grid_mapping_name == self.GRID_MAPPING_LAMBERT_CYLINDRICAL:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_ORTHO:
+        elif grid_mapping_name == self.GRID_MAPPING_ORTHO:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_POLAR:
+        elif grid_mapping_name == self.GRID_MAPPING_POLAR:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_STEREO:
+        elif grid_mapping_name == self.GRID_MAPPING_STEREO:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_TRANSVERSE:
+        elif grid_mapping_name == self.GRID_MAPPING_TRANSVERSE:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
-        elif grid_mapping_name == GRID_MAPPING_VERTICAL:
+        elif grid_mapping_name == self.GRID_MAPPING_VERTICAL:
             # Grid mapping type not handled yet.
             raise NotImplementedError(f'Grid mapping name {grid_mapping_name} is not currently supported.')
         else:

--- a/nctotdb/readers.py
+++ b/nctotdb/readers.py
@@ -392,7 +392,7 @@ class TDBReader(Reader):
         # Dim Coords And Dims (mapping of coords to cube axes).
         dcad = [(group_dims[name], i) for i, name in enumerate(dim_names)]
         safe_attrs = self._handle_attributes(metadata,
-                                             exclude_keys=['dataset', 'multiattr'])
+                                             exclude_keys=['dataset', 'multiattr', 'grid_mapping'])
         std_name = metadata.pop('standard_name', None)
         long_name = metadata.pop('long_name', None)
         var_name = metadata.pop('var_name', None)
@@ -443,7 +443,11 @@ class TDBReader(Reader):
         """
         grid_mapping = None
         with tiledb.open(data_array_path, 'r') as A:
-            grid_mapping_str = A.meta.pop('grid_mapping', None)
+            try:
+                grid_mapping_str = A.meta['grid_mapping']
+            except KeyError:
+                grid_mapping_str = None
+        print(grid_mapping_str)
         if grid_mapping_str is not None and grid_mapping_str != 'none':
             # Cannot write NoneType into TileDB array meta, so `'none'` is a
             # stand-in that must be caught.

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -190,7 +190,7 @@ class TDBWriter(Writer):
         array metadata.
 
         """
-        grid_mapping_name = data_var.get(grid_mapping, None)
+        grid_mapping_name = data_var.getncattr("grid_mapping")
         result = 'none'  # TileDB probably won't support `NoneType` in array meta.
         if grid_mapping_name is not None:
             assert grid_mapping_name in self.data_model.grid_mapping
@@ -438,6 +438,9 @@ class MultiAttrTDBWriter(TDBWriter):
                 A.meta['dataset'] = ','.join(data_var_names)
                 # Define this as being a multi-attr array.
                 A.meta['multiattr'] = True
+                # Add grid mapping metadata as a JSON string.
+                grid_mapping_string = self._get_grid_mapping(data_vars[0])
+                A.meta['grid_mapping'] = grid_mapping_string
                 # XXX: can't add list or tuple as values to metadata dictionary...
                 dim_coord_names = self.data_model.variables[data_var_names[0]].dimensions
                 A.meta['dimensions'] = ','.join(n for n in dim_coord_names)

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -8,6 +8,7 @@ import tiledb
 import zarr
 
 from .data_model import NCDataModel
+from .grid_mappings import store_grid_mapping
 
 
 class Writer(object):
@@ -182,6 +183,21 @@ class TDBWriter(Writer):
         """Set the array indices to write the array data into."""
         return _array_indices(shape, start_index)
 
+    def _get_grid_mapping(self, data_var):
+        """
+        Get the data variable's grid mapping variable, encode it as a JSON string
+        for easy storage in the TileDB array's meta and return it for storage as
+        array metadata.
+
+        """
+        grid_mapping_name = data_var.get(grid_mapping, None)
+        result = 'none'  # TileDB probably won't support `NoneType` in array meta.
+        if grid_mapping_name is not None:
+            assert grid_mapping_name in self.data_model.grid_mapping
+            grid_mapping_var = self.data_model.variables[grid_mapping_name]
+            result = store_grid_mapping(grid_mapping_var)
+        return result
+
     def populate_array(self, var_name, data_var, group_dirname,
                        start_index=None, write_meta=True):
         """Write the contents of a netcdf data variable into a tiledb array."""
@@ -203,6 +219,9 @@ class TDBWriter(Writer):
                     A.meta['dataset'] = var_name
                     # Define this as not being a multi-attr array.
                     A.meta['multiattr'] = False
+                    # Add grid mapping metadata as a JSON string.
+                    grid_mapping_string = self._get_grid_mapping(data_var)
+                    A.meta['grid_mapping'] = grid_mapping_string
                     # XXX: can't add list or tuple as values to metadata dictionary...
                     dim_coord_names = self.data_model.variables[var_name].dimensions
                     A.meta['dimensions'] = ','.join(n for n in dim_coord_names)


### PR DESCRIPTION
Get grid mapping metadata from the incoming NetCDF file and write it, as a JSON string, to the meta of the TileDB data array. On the Iris read side, translate the JSON string in the TileDB array meta into an Iris coord system object and add it to the cube and the horizontal coordinates.