### PR TITLE
Explicitly open/close NetCDF file

### DIFF
--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -48,6 +48,7 @@ class NCDataModel(object):
             self.open()
             self.classify_variables()
             self.get_metadata()
+            yield
         finally:
             self.close()
 

--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -8,24 +8,26 @@ import tiledb
 
 
 class NCDataModel(object):
-    data_var_names = []
-    dim_coord_names = []
-    scalar_coord_names = []
-    aux_coord_names = []
-    bounds = []
-    grid_mapping = []
-    cell_methods = []
-    cell_measures = []
-    unlimited_dim_coords = []
-
-    domains = []
-    domain_varname_mapping = None
-    varname_domain_mapping = None
-    shape = None
-    chunks = None
 
     def __init__(self, netcdf_filename):
         self.netcdf_filename = netcdf_filename
+
+        self.data_var_names = []
+        self.dim_coord_names = []
+        self.scalar_coord_names = []
+        self.aux_coord_names = []
+        self.bounds = []
+        self.grid_mapping = []
+        self.cell_methods = []
+        self.cell_measures = []
+        self.unlimited_dim_coords = []
+
+        self.domains = []
+        self.domain_varname_mapping = None
+        self.varname_domain_mapping = None
+        self.shape = None
+        self.chunks = None
+
         self._classified = False
 
     def open(self):
@@ -153,9 +155,6 @@ class NCDataModel(object):
 
         """
         # Work out the shapes of each variable. The most enclosing domains will have the highest ndim.
-        print(f'NetCDF file: {self._ncds.filepath()}\n')
-        print(f'Variable names: {self.variable_names}\n')
-        print(f'Data var names: {self.data_var_names}')
         ndims = np.array([len(self.variables[var_name].shape) for var_name in self.data_var_names])
         max_ndim = max(ndims)
         # Get the variables that describe the most enclosing domains (super domains).

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -921,6 +921,7 @@ def _make_multiattr_tile(other_data_model, domain_path, data_array_name,
     offsets = [0] * len(shape)
     offsets[append_axis] = offset
     offset_inds = _array_indices(shape, offsets)
+    logging.error(f'Append inds for {other_data_model.netcdf_filename!r}: {offset_inds}')
 
     # Append the data from other.
     data_array_path = f"{domain_path}{data_array_name}"
@@ -960,6 +961,7 @@ def _make_multiattr_tile_helper(serialized_job):
 
     # To improve fault tolerance all the processing happens in a try/except...
     try:
+        print(job_args.other)
         other_data_model = NCDataModel(job_args.other)
         other_data_model.classify_variables()
         other_data_model.get_metadata()
@@ -985,6 +987,8 @@ def _make_multiattr_tile_helper(serialized_job):
     except Exception as e:
         emsg = f'Could not process {job_args.other!r}. See below for details:\n{e}\n'
         logging.error(emsg, exc_info=True)
+        if job_args.logfile is None and job_args.verbose:
+            raise
 
 
 def _make_tile(other, domain_path, var_name, append_axis, append_dim,

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -905,6 +905,10 @@ def _make_multiattr_tile(other_data_model, domain_path, data_array_name,
     other_dim_var = other_data_model.variables[append_dim]
     other_dim_points = np.atleast_1d(other_dim_var[:])
 
+    # Check for the dataset being scalar on the append dimension.
+    if not scalar_coord and len(other_dim_points) == 1:
+        scalar_coord = True
+
     if scalar_coord:
         shape = [1] + list(data_var_shape)
     else:
@@ -952,7 +956,7 @@ def _make_multiattr_tile_helper(serialized_job):
     append_axes = job_args.axis
 
     # Record what we've processed...
-    logging.info(f'Processing {job_args.other!r}')
+    logging.error(f'Processing {job_args.other!r} ({job_args.job_number+1}/{job_args.n_jobs})')
 
     # To improve fault tolerance all the processing happens in a try/except...
     try:


### PR DESCRIPTION
Adds a context manager for opening, classifying and closing a NetCDF file to the data model. Also used by append methods in `writers.py` when creating data models for files to be appended.

Rationale: not explicitly closing NetCDF files was leading to old open handles hanging around and causing bizarre errors (and data inaccuracies) when handling multiple NetCDF files - particularly when appending in parallel.

Also closes #34.  