### PR TITLE
Also update the writer public API name

### DIFF
--- a/nctotdb/__init__.py
+++ b/nctotdb/__init__.py
@@ -1,4 +1,4 @@
 from .data_model import NCDataModel
 from .grid_mappings import GridMapping, store_grid_mapping
 from .readers import TDBReader, ZarrReader
-from .writers import TDBWriter, ZarrWriter
+from .writers import TileDBWriter, ZarrWriter

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -411,7 +411,7 @@ class _TDBWriter(Writer):
         self._fill_missing_points(coord_array_path, append_dim_name, verbose=verbose)
 
 
-class TDBWriter(_TDBWriter):
+class TileDBWriter(_TDBWriter):
     """
     Write Python objects loaded from NetCDF to TileDB, including writing TileDB
     arrays with multiple data attributes from different NetCDF data variables


### PR DESCRIPTION
The tiledb writer class does not have the greatest name, so let's update it: `TDBWriter` --> `TileDBWriter`, which is a better and more accurate name 🎉 