### PR TITLE
Also update reader public API name

### DIFF
--- a/nctotdb/__init__.py
+++ b/nctotdb/__init__.py
@@ -1,4 +1,4 @@
 from .data_model import NCDataModel
 from .grid_mappings import GridMapping, store_grid_mapping
-from .readers import TDBReader, ZarrReader
+from .readers import TileDBReader, ZarrReader
 from .writers import TileDBWriter, ZarrWriter

--- a/nctotdb/readers.py
+++ b/nctotdb/readers.py
@@ -112,7 +112,7 @@ class Reader(object):
         raise NotImplementedError
 
 
-class TDBReader(Reader):
+class TileDBReader(Reader):
     def __init__(self, array_name, array_filepath=None, container=None,
                  storage_options=None, data_array_name=None, ctx=None):
         super().__init__(array_filepath)


### PR DESCRIPTION
Also update the TileDB reader public API name in the same way as the writer API was updated in #40. To wit, `TDBReader` --> `TileDBReader`.

Honestly, if I were trying to game a "PRs raised metric", I'd be _doing great_ right now.