### PR TITLE
setup.py: Add installation script.

### DIFF
--- a/etc/Dockerfile
+++ b/etc/Dockerfile
@@ -1,0 +1,52 @@
+FROM python:3.7
+
+# Enable discovery of PROJ shared objects files
+ENV LD_LIBRARY_PATH /lib:/usr/lib:/usr/local/lib
+
+# Install PROJ - dependency for cartopy (a dependency of scitools-iris)
+RUN apt-get update && \
+    apt-get install -y sqlite3 && \
+    wget https://download.osgeo.org/proj/proj-7.0.0.tar.gz && \
+    tar -xf proj-7.0.0.tar.gz && \
+    cd proj-7.0.0 && \
+    ./configure && \
+    make && \
+    make install && \
+    projsync --system-directory --all && \
+    cd ..
+
+# Install GEOS - dependency for cartopy (a dependency of scitools-iris)
+# RUN apt-get install -y libgeos-dev
+RUN wget http://download.osgeo.org/geos/geos-3.8.1.tar.bz2 && \
+    tar -xf geos-3.8.1.tar.bz2 && \
+    cd geos-3.8.1 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd ..
+
+# scitools-iris has a dependency on cf_units, which is itself a wrapper around the UDUNITS-2 C library. Install UDUNITS-2 library below.
+RUN wget ftp://ftp.unidata.ucar.edu/pub/udunits/udunits-2.2.26.tar.gz && \
+    tar -xf udunits-2.2.26.tar.gz && \
+    cd udunits-2.2.26 && \
+    ./configure && \
+    make && \
+    make install && \
+    cd ..
+
+# scitools-iris has a dependency on pyke, which is not available through pypi. pyke be installed manually.
+RUN wget https://sourceforge.net/projects/pyke/files/pyke/1.1.1/pyke3-1.1.1.zip/download -O pyke3-1.1.1.zip && \
+    unzip pyke3-1.1.1.zip && \
+    cd pyke-1.1.1 && \
+    python setup.py install && \
+    cd ..
+
+# Must have an available numpy installation (1.10+) prior to installing cartopy during setup.py
+RUN pip install numpy==1.18.5
+
+COPY . /tiledb_netcdf
+WORKDIR /tiledb_netcdf
+
+RUN pip install .
+
+ENTRYPOINT ["python"]

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,3 @@
+# Installing tiledb_netcdf
+
+We acknowledge that, at the moment, installing all the dependencies for the project is a little bit of a pain. The accompanying `Dockerfile` in this directory illustrates how to install all the project requirements from scratch.

--- a/setup.py
+++ b/setup.py
@@ -21,9 +21,7 @@ setuptools.setup(
     ],
     python_requires=">=3.7",
     install_requires=[
-        "netCDF4>=1.5.3",
-        "tiledb>=0.6.2",
-        "numpy>=1.18.5",
+        "tiledb>=0.6.6",
         "scitools-iris>=2.4.0",
         "xarray>=0.15.1",
         "zarr>=2.4.0"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,31 @@
+import setuptools
+
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="tiledb_netcdf",
+    version="0.1.0",
+    author="Peter Killick",
+    author_email="peter.killick@informaticslab.co.uk",
+    description="An adapter to convert NetCDF files to TileDB or Zarr arrays",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/informatics-lab/tiledb_netcdf",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Operating System :: OS Independent",
+    ],
+    python_requires=">=3.7",
+    install_requires=[
+        "netCDF4>=1.5.3",
+        "tiledb>=0.6.2",
+        "numpy>=1.18.5",
+        "scitools-iris>=2.4.0",
+        "xarray>=0.15.1",
+        "zarr>=2.4.0"
+    ]
+)


### PR DESCRIPTION
Creates a `setup.py` file, as per #44 

This is also can also be `pip install`ed from TestPyPI using the steps [here](https://packaging.python.org/tutorials/packaging-projects/).

I've also created a Dockerfile to demonstrate the build's reproducibility, which can be seen [here](https://github.com/grumbling-tom/tiledb_netcdf/blob/feature/dockerfile/Dockerfile). Given the number of C library dependencies, it might be worth including in this PR, purely for illustration on installing those libraries.