### PR TITLE
Redo closed NC file handling

### DIFF
--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -11,6 +11,7 @@ class NCDataModel(object):
 
     def __init__(self, netcdf_filename):
         self.netcdf_filename = netcdf_filename
+        self._ncds = None
 
         self.data_var_names = []
         self.dim_coord_names = []
@@ -53,6 +54,13 @@ class NCDataModel(object):
             yield
         finally:
             self.close()
+
+    def dataset_open(self):
+        """Check if the dataset has been loaded and is still open."""
+        result = False
+        if self._ncds is not None:
+            result = self._ncds.isopen()
+        return result
 
     def populate(self):
         with self.open_netcdf():


### PR DESCRIPTION
Re-fixes #52 in a simpler and more general manner than #53 provided.

Now the dataset is opened once as a property in the abstract `Writer` class. This means we can also remove the duplicated `with` blocks in the `Writer` implementation classes.