### PR TITLE
Dask integration

### DIFF
--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -3,13 +3,11 @@ import numpy as np
 import tiledb
 
 
-SLOTS = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
-
 # Inspired by https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/netcdf.py#L418.
 class TileDBDataProxy(object):
     """A proxy to the data of a single TileDB array attribute."""
 
-    __slots__ = SLOTS
+    __slots__ = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
 
     def __init__(self, shape, dtype, path, var_name, ctx=None, handle_nan=None):
         self.shape = shape
@@ -80,21 +78,20 @@ class TileDBDataProxy(object):
         """Restore the complex object from the simple pickled dict."""
         deserialized_state = deserialize_state(state)
         for key, value in deserialized_state.items():
-            setattr(self, key, value)
+            if key in self.__slots__:
+                setattr(self, key, value)
 
 
 def deserialize_state(s_state):
     """
     Take a serialized dictionary of state and deserialize it to set state
-    on a TileDBDataProxy instance.
+    on a `TileDBDataProxy` instance.
 
     """
     d_state = {}
     for key, s_value in s_state.items():
         if key == "shape":
-            if key not in SLOTS:
-                continue
-            elif s_value["type"] == "tuple":
+            if s_value["type"] == "tuple":
                 result = [slice(*l) for l in s_value["value"]]
                 d_value = tuple(result)
             elif s_value["type"] == "list":

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -1,10 +1,10 @@
-from distributed.protocol.numpy import serialize_numpy_maskedarray, deserialize_numpy_maskedarray
+from distributed.protocol import dask_serialize, dask_deserialize
 import numpy as np
 import tiledb
 
 
 # Inspired by https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/netcdf.py#L418.
-class TileDBDataProxy:
+class TileDBDataProxy(object):
     """A proxy to the data of a single TileDB array attribute."""
 
     __slots__ = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
@@ -33,33 +33,86 @@ class TileDBDataProxy:
                     raise ValueError(f'Not a valid nan-handling approach: {self.handle_nan!r}.')
         return data
 
+    def serialize_state(self, dummy=None):
+        """
+        Take the current state of `self` and make it serializable.
+
+        Note the apparently unused kwarg `dummy`. This allows `serialize_state` to be used
+        as the 'default' serialization function for msgpack. For example:
+
+        ```
+        msgpack.dumps(my_data_proxy, default=my_data_proxy.serialize_state)
+        ```
+
+        In such instances, msgpack calls `default` with the object to be dumped, which makes
+        no sense in this application.
+
+        """
+        state = {}
+        for attr in self.__slots__:
+            value = getattr(self, attr)
+            if attr == "shape":
+                # `shape` could either be a simple list (of np.int!) or a tuple of slices...
+                result = {"type": None, "value": None}
+                if isinstance(value, tuple):
+                    result["type"] = "tuple"
+                    result["value"] = [[int(s.start), int(s.stop), int(s.step)] for s in value]
+                else:
+                    result["type"] = "list"
+                    result["value"] = [int(i) for i in value]
+                state[attr] = result
+            elif attr == "dtype":
+                state[attr] = np.dtype(value).str
+            elif attr == "ctx":
+                # ctx is based on a C library that doesn't pickle...
+                state[attr] = value.config().dict() if value is not None else None
+            else:
+                state[attr] = value
+        return state
+
     def __getstate__(self):
-        return {attr: getattr(self, attr) for attr in self.__slots__}
+        """Simplify a complex object for pickling."""
+        return self.serialize_state()
 
     def __setstate__(self, state):
-        for key, value in state.items():
+        """Restore the complex object from the simple pickled dict."""
+        deserialized_state = deserialize_state(state)
+        for key, value in deserialized_state.items():
             setattr(self, key, value)
 
 
+def deserialize_state(s_state):
+    """
+    Take a serialized dictionary of state and deserialize it to set state
+    on a TileDBDataProxy instance.
+
+    """
+    d_state = {}
+    for key, s_value in s_state.items():
+        if key == "shape":
+            if s_value["type"] == "tuple":
+                result = [slice(*l) for l in s_value["value"]]
+                d_value = tuple(result)
+            elif s_value["type"] == "list":
+                d_value = s_value["value"]
+            else:
+                raise RuntimeError(f"Cannot deserialize {key!r} with type {s_value['type']!r}.")
+        elif key == "dtype":
+            d_value = np.dtype(s_value)
+        elif key == "ctx":
+            d_value = tiledb.Ctx(config=tiledb.Config(s_value)) if s_value is not None else None
+        else:
+            d_value = s_value
+        d_state[key] = d_value
+    return d_state
+
+
+@dask_serialize.register(TileDBDataProxy)
 def tdb_data_proxy_dumps(data_proxy):
-    header = {"shape": data_proxy.shape,
-              "dtype": data_proxy.dtype,
-              "path": data_proxy.path,
-              "var_name": data_proxy.var_name,
-              "handle_nan": data_proxy.handle_nan,
-              "ctx": data_proxy.ctx.config().dict() if data_proxy.ctx is not None else None}
-    return header, []
+    return data_proxy.serialize_state(), []
 
 
+@dask_deserialize.register(TileDBDataProxy)
 def tdb_data_proxy_loads(header, frames):
-    if header["ctx"] is not None:
-        ctx = tiledb.Ctx(config=tiledb.Config(header["ctx"]))
-    else:
-        ctx = None
-    result = TileDBDataProxy(header["shape"],
-                             header["dtype"],
-                             header["path"],
-                             header["var_name"],
-                             ctx=ctx,
-                             handle_nan=header["handle_nan"])
-    return result
+    deserialized_state = deserialize_state(header)
+    return TileDBDataProxy(**deserialized_state)

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -3,11 +3,13 @@ import numpy as np
 import tiledb
 
 
+SLOTS = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
+
 # Inspired by https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/netcdf.py#L418.
 class TileDBDataProxy(object):
     """A proxy to the data of a single TileDB array attribute."""
 
-    __slots__ = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
+    __slots__ = SLOTS
 
     def __init__(self, shape, dtype, path, var_name, ctx=None, handle_nan=None):
         self.shape = shape
@@ -90,7 +92,9 @@ def deserialize_state(s_state):
     d_state = {}
     for key, s_value in s_state.items():
         if key == "shape":
-            if s_value["type"] == "tuple":
+            if key not in SLOTS:
+                continue
+            elif s_value["type"] == "tuple":
                 result = [slice(*l) for l in s_value["value"]]
                 d_value = tuple(result)
             elif s_value["type"] == "list":

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -1,0 +1,65 @@
+from distributed.protocol.numpy import serialize_numpy_maskedarray, deserialize_numpy_maskedarray
+import numpy as np
+import tiledb
+
+
+# Inspired by https://github.com/SciTools/iris/blob/master/lib/iris/fileformats/netcdf.py#L418.
+class TileDBDataProxy:
+    """A proxy to the data of a single TileDB array attribute."""
+
+    __slots__ = ("shape", "dtype", "path", "var_name", "ctx", "handle_nan")
+
+    def __init__(self, shape, dtype, path, var_name, ctx=None, handle_nan=None):
+        self.shape = shape
+        self.dtype = dtype
+        self.path = path
+        self.var_name = var_name
+        self.ctx = ctx
+        self.handle_nan = handle_nan
+
+    @property
+    def ndim(self):
+        return len(self.shape)
+
+    def __getitem__(self, keys):
+        with tiledb.open(self.path, 'r', ctx=self.ctx) as A:
+            data = A[keys][self.var_name]
+            if self.handle_nan is not None:
+                if self.handle_nan == 'mask':
+                    data = np.ma.masked_invalid(data, np.nan)
+                elif type(self.handle_nan) in [int, float]:
+                    data = np.nan_to_num(data, nan=self.handle_nan, copy=False)
+                else:
+                    raise ValueError(f'Not a valid nan-handling approach: {self.handle_nan!r}.')
+        return data
+
+    def __getstate__(self):
+        return {attr: getattr(self, attr) for attr in self.__slots__}
+
+    def __setstate__(self, state):
+        for key, value in state.items():
+            setattr(self, key, value)
+
+
+def tdb_data_proxy_dumps(data_proxy):
+    header = {"shape": data_proxy.shape,
+              "dtype": data_proxy.dtype,
+              "path": data_proxy.path,
+              "var_name": data_proxy.var_name,
+              "handle_nan": data_proxy.handle_nan,
+              "ctx": data_proxy.ctx.config().dict() if data_proxy.ctx is not None else None}
+    return header, []
+
+
+def tdb_data_proxy_loads(header, frames):
+    if header["ctx"] is not None:
+        ctx = tiledb.Ctx(config=tiledb.Config(header["ctx"]))
+    else:
+        ctx = None
+    result = TileDBDataProxy(header["shape"],
+                             header["dtype"],
+                             header["path"],
+                             header["var_name"],
+                             ctx=ctx,
+                             handle_nan=header["handle_nan"])
+    return result

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setuptools.setup(
     ],
     python_requires=">=3.7",
     install_requires=[
+        "distributed>=2.28.0",
         "tiledb>=0.6.6",
         "scitools-iris>=2.4.0",
         "xarray>=0.15.1",


### PR DESCRIPTION
To enable use of dask distributed with TileDB arrays created using this library, we only need to be able to pass the data proxy to dask workers. To do this the data proxy needs to be serializable (and deserializable), and provided with a specific set of functions for dask to use for serializing / deserializing. This PR enables such serialization, and moves the data proxy to its own module, with the proxy having acquired some more functionality.