### PR TITLE
Serializing the proxy, again

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/Users/DPeterK/miniconda3/bin/python"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/Users/DPeterK/miniconda3/bin/python"
-}

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -91,3 +91,13 @@ def deserialize_state(s_state):
             d_value = s_value
         d_state[key] = d_value
     return d_state
+
+
+@dask_serialize.register(TileDBDataProxy)
+def tdb_data_proxy_dumps(data_proxy):
+    return data_proxy.serialize_state(), []
+
+
+@dask_deserialize.register(TileDBDataProxy)
+def tdb_data_proxy_loads(header, frames):
+    return dpickle.loads(header)

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -91,13 +91,3 @@ def deserialize_state(s_state):
             d_value = s_value
         d_state[key] = d_value
     return d_state
-
-
-@dask_serialize.register(TileDBDataProxy)
-def tdb_data_proxy_dumps(data_proxy):
-    return data_proxy.serialize_state(), []
-
-
-@dask_deserialize.register(TileDBDataProxy)
-def tdb_data_proxy_loads(header, frames):
-    return dpickle.loads(header)

--- a/nctotdb/proxy.py
+++ b/nctotdb/proxy.py
@@ -1,5 +1,4 @@
 from distributed.protocol import dask_serialize, dask_deserialize
-import distributed.protocol.pickle as dpickle
 import numpy as np
 import tiledb
 
@@ -91,13 +90,3 @@ def deserialize_state(s_state):
             d_value = s_value
         d_state[key] = d_value
     return d_state
-
-
-@dask_serialize.register(TileDBDataProxy)
-def tdb_data_proxy_dumps(data_proxy):
-    return data_proxy.serialize_state(), []
-
-
-@dask_deserialize.register(TileDBDataProxy)
-def tdb_data_proxy_loads(header, frames):
-    return dpickle.loads(header)


### PR DESCRIPTION
The existing approach for serializing the data proxy is overly complex: it creates a new data proxy object and includes bespoke serializers to be registered with dask that turn out to be unnecessary, and to just be making life difficult. In fact, the data proxy class is now pickleable, meaning that dask can just hand off to pickle for serializing and deserializing proxy objects. This means that the bespoke serializers for dask are no longer needed, so have been removed.