### PR TITLE
ENH: Combine data models

### DIFF
--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -63,6 +63,10 @@ class NCDataModel(object):
             result = self._ncds.isopen()
         return result
 
+    @property
+    def data_vars_mapping(self):
+        return None
+
     def populate(self):
         with self.open_netcdf():
             self.classify_variables()

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -485,9 +485,13 @@ class TileDBWriter(_TDBWriter):
         return separator.join(dimensions)
 
     def _get_attributes(self, data_var):
+        ncattrs = data_var.ncattrs()
         metadata = {}
-        for ncattr in data_var.ncattrs():
+        for ncattr in ncattrs:
             metadata[ncattr] = data_var.getncattr(ncattr)
+        # Add a fallback long_name in case of both standard_name and long_name being missing.
+        if "standard_name" not in ncattrs and "long_name" not in ncattrs:
+            metadata["long_name"] = data_var.name
         return metadata
 
     def _multi_attr_metadata(self, data_var_names):


### PR DESCRIPTION
New functionality to combine `DataModel` objects into a new `DataModelGroup` object, which is conceptually a little like a NetCDF group. The value of this new object comes when you have a number of NetCDF files that all contain a single phenomenon at the same spatio-temporal location, and you'd like to combine the contents of all the NetCDF files to create and extend a multi-attr TileDB array. For example:

```
file1.nc: PMSL     - t=0, x=0-100, y=0-100 |
file2.nc: humidity - t=0, x=0-100, y=0-100 | -->  TileDB array: (PMSL, humidity, air temp), t=0, x=0-100, y=0-100
file3.nc: air temp - t=0, x=0-100, y=0-100 |
```

So, we can create a single, multi-attr TileDB array from multiple single-phenomenon input NetCDF files, rather than being limited to creating one TileDB array per NetCDF file.

The `DataModelGroup` exposes an identical API to the existing `DataModel`, so can be used interchangeably in downstream code. 