### PR TITLE
[ENH] Combine data models

### DIFF
--- a/nctotdb/data_model.py
+++ b/nctotdb/data_model.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 from contextlib import contextmanager
+from hashlib import md5
 import os
 
 import netCDF4
@@ -62,6 +63,10 @@ class NCDataModel(object):
             result = self._ncds.isopen()
         return result
 
+    @property
+    def data_vars_mapping(self):
+        return None
+
     def populate(self):
         with self.open_netcdf():
             self.classify_variables()
@@ -97,6 +102,9 @@ class NCDataModel(object):
             elif hasattr(variable, 'coordinates'):
                 self.data_var_names.append(variable_name)
                 classified_vars.append(variable_name)
+                # If it's a data variable it might also have cell methods.
+                if hasattr(variable, 'cell_methods'):
+                    self.cell_methods.append(variable.cell_methods)
 
             # Check if this variable is a coordinate - dimension or aux.
             elif hasattr(variable, 'dimensions'):
@@ -118,11 +126,6 @@ class NCDataModel(object):
             elif hasattr(variable, 'cell_measures'):
                 self.cell_measures.append(variable_name)
                 classified_vars.append(variable_name)
-                classified_vars.append(variable_name)
-
-            # TODO: check if it's a cell method variable
-#             elif hasattr(variable, 'cell_measures'):
-#                 pass
 
         # What have we still missed?
         unclassified_vars = list(set(self.variable_names) - set(classified_vars))
@@ -250,3 +253,216 @@ class NCDataModel(object):
 
         # Also create the inverse mapping of var_name --> domain.
         self.varname_domain_mapping = {vi: k for k, v in self.domain_varname_mapping.items() for vi in v}
+
+
+def metadata_hash(data_model, name):
+    """
+    Produce a completely predictable hash from the metadata of a data model.
+    This will make it possible to correctly index an existing array to append
+    further data onto the correct index of the existing array.
+
+    The predictable metadata hash of the array is of the form:
+        ```name(s)_hash```
+
+    where:
+        * `name` is the name(s) of the dataset (CF standard_name if available)
+        * `hash` is an md5 hash of a standardised subset of the data model's metadata.
+
+    The metadata that makes up the hash is as follows:
+        * name of data variable
+        * shape of dataset
+        * dimension coordinate names
+        * grid_mapping name
+        * string of cell methods applied to dataset.
+
+    """
+    dims = ",".join(data_model.dim_coord_names)
+    grid_mapping = ",".join(data_model.grid_mapping)
+    cell_methods = ",".join(data_model.cell_methods)
+
+    to_hash = f"{name}_{dims}_{data_model.shape}_{grid_mapping}_{cell_methods}"
+    metadata_hash = md5(to_hash.encode("utf-8")).hexdigest()
+
+    return f"{name}_{metadata_hash}"
+
+
+class _VarDimLookup(object):
+    def __init__(self,
+                 primary_data_model,
+                 data_vars_mapping=None,
+                 variables=True,
+                 can_be_none=False):
+        self.primary_data_model = primary_data_model
+        self.data_vars_mapping = data_vars_mapping
+        self.variables = variables
+        self.data_model_attr = "variables" if self.variables else "dimensions"
+        self.can_be_none = can_be_none
+
+        self._data_var_names = None
+
+    @property
+    def data_var_names(self):
+        if self._data_var_names is None:
+            if self.data_vars_mapping is not None:
+                self.data_var_names = list(self.data_vars_mapping.keys())
+            else:
+                self.data_var_names = []
+        return self._data_var_names
+
+    @data_var_names.setter
+    def data_var_names(self, value):
+        self._data_var_names = value
+
+    def __getitem__(self, keys):
+        if keys in self.data_var_names:
+            target = self.data_vars_mapping[keys]
+        else:
+            result = self.primary_data_model
+            target = [result, keys]
+
+        target_data_model, original_key = target
+        try:
+            result = getattr(target_data_model, self.data_model_attr)[original_key]
+        except KeyError:
+            if self.can_be_none:
+                result = None
+            else:
+                raise
+        return result
+
+
+class NCDataModelGroup(object):
+    """
+    Combine multiple data model instances (each with only a single data variable)
+    into an amalgam data model containing multiple data variables.
+
+    It is assumed (but not currently programatically confirmed) that all data
+    model instances are otherwise identical (that is, all other metadata matches),
+    and only the data variable changes between instances. Failure to heed this
+    limitation will likely lead to broken TileDB / Zarr arrays.
+
+    """
+    def __init__(self, data_models):
+        self._data_models = data_models
+
+        self._load()
+        self.verify()
+
+        self._primary_data_model = None
+        self._data_var_names = None
+        self._data_vars_mapping = None
+
+        self.netcdf_filename = self.primary_data_model.netcdf_filename
+        self.variables = _VarDimLookup(self.primary_data_model,
+                                       data_vars_mapping=self.data_vars_mapping,
+                                       can_be_none=None in self.data_models)
+        self.dimensions = _VarDimLookup(self.primary_data_model,
+                                        variables=False)
+
+    def __getattr__(self, name):
+        """
+        Pass on all unhandled attribute get requests to the primary data model,
+        which is assumed to be representative of all encapsulated data models
+        with regard to other metadata.
+
+        """
+        return getattr(self.primary_data_model, name)
+
+    @property
+    def data_models(self):
+        return self._data_models
+
+    @data_models.setter
+    def data_models(self, value):
+        self._data_models = value
+
+    @property
+    def primary_data_model(self):
+        """The 'primary' data model is the first non-None data model in the list."""
+        if self._primary_data_model is None:
+            result = None
+            for data_model in self.data_models:
+                if data_model is not None:
+                    result = data_model
+                    break
+            self.primary_data_model = result
+        return self._primary_data_model
+
+    @primary_data_model.setter
+    def primary_data_model(self, value):
+        self._primary_data_model = value
+
+    @property
+    def data_var_names(self):
+        if self._data_var_names is None:
+            self.data_var_names = list(self.data_vars_mapping.keys())
+        return self._data_var_names
+
+    @data_var_names.setter
+    def data_var_names(self, value):
+        self._data_var_names = value
+
+    @property
+    def data_vars_mapping(self):
+        if self._data_vars_mapping is None:
+            self.data_vars_mapping = self._map_data_vars()
+        return self._data_vars_mapping
+
+    @data_vars_mapping.setter
+    def data_vars_mapping(self, value):
+        self._data_vars_mapping = value
+
+    def _map_data_vars(self):
+        """Create a mapping of data variable names to the data model supplying that data variable."""
+        dv_mapping = {}
+        for dm in self.data_models:
+            if dm is not None:
+                for name in dm.data_var_names:
+                    hashed_name = metadata_hash(dm, name)
+                    dv_mapping[hashed_name] = [dm, name]
+        return dv_mapping
+
+    @contextmanager
+    def open_netcdf(self):
+        try:
+            self.open()
+            yield
+        finally:
+            self.close()
+
+    def _load(self):
+        """Ensure all data models passed to the constructor are DataModel objects or None."""
+        dms = []
+        for data_model in self.data_models:
+            if isinstance(data_model, str):
+                try:
+                    dm = NCDataModel(data_model)
+                    dm.populate()
+                except (FileNotFoundError, AttributeError):
+                    dm = None
+                dms.append(dm)
+            else:
+                dms.append(data_model)
+        self.data_models = dms
+
+    def open(self):
+        for data_model in self.data_models:
+            if data_model is not None:
+                data_model.open()
+
+    def close(self):
+        for data_model in self.data_models:
+            if data_model is not None:
+                data_model.close()
+
+    def dataset_open(self):
+        """
+        This 'dataset' (specifically a group of datasets) can only be considered
+        'open' if all the datasets that comprise it are open.
+
+        """
+        return all([dm.dataset_open() for dm in self.data_models if dm is not None])
+
+    def verify(self):
+        """Not implemented!"""
+        pass

--- a/nctotdb/writers.py
+++ b/nctotdb/writers.py
@@ -8,7 +8,7 @@ import numpy as np
 import tiledb
 import zarr
 
-from .data_model import NCDataModel
+from .data_model import NCDataModel, NCDataModelGroup
 from .grid_mappings import store_grid_mapping
 from .paths import PosixArrayPath, AzureArrayPath
 from . import utils
@@ -17,7 +17,7 @@ from . import utils
 append_arg_list = ['other', 'domain', 'name', 'axis', 'dim',
                    'ind_stop', 'dim_stop', 'step', 'scalar',
                    'mapping', 'verbose', 'job_number', 'n_jobs',
-                   'make_data_model', 'offset', 'ctx', 'logfile']
+                   'make_data_model', 'group', 'offset', 'ctx', 'logfile']
 defaults = [None] * len(append_arg_list)
 AppendArgs = namedtuple('AppendArgs', append_arg_list, defaults=defaults)
 
@@ -33,7 +33,7 @@ class Writer(object):
                  unlimited_dims=None, ctx=None):
         self._data_model = data_model
         self.array_filepath = array_filepath
-        self.container = container  # Azure container name.
+        self.container = container  # Azure container name.
         self.unlimited_dims = unlimited_dims
         self.ctx = ctx  # TileDB Context object.
 
@@ -485,9 +485,13 @@ class TileDBWriter(_TDBWriter):
         return separator.join(dimensions)
 
     def _get_attributes(self, data_var):
+        ncattrs = data_var.ncattrs()
         metadata = {}
-        for ncattr in data_var.ncattrs():
+        for ncattr in ncattrs:
             metadata[ncattr] = data_var.getncattr(ncattr)
+        # Add a fallback long_name in case of both standard_name and long_name being missing.
+        if "standard_name" not in ncattrs and "long_name" not in ncattrs:
+            metadata["long_name"] = data_var.name
         return metadata
 
     def _multi_attr_metadata(self, data_var_names):
@@ -534,7 +538,7 @@ class TileDBWriter(_TDBWriter):
         array_filename = self.array_path.construct_path(domain_name, data_array_name)
 
         # Write to the array.
-        data_vars = [self.data_model.variables[name] for name in data_var_names]
+        data_vars = {name: self.data_model.variables[name] for name in data_var_names}
         scalar = self._scalar_unlimited is not None
         write_multiattr_array(array_filename, data_vars,
                               start_index=start_index, scalar=scalar, ctx=self.ctx)
@@ -550,7 +554,8 @@ class TileDBWriter(_TDBWriter):
                 # Define this as being a multi-attr array.
                 A.meta['multiattr'] = True
                 # Add grid mapping metadata as a JSON string.
-                grid_mapping_string = self._get_grid_mapping(data_vars[0])
+                zeroth_data_var = list(data_vars.values())[0]
+                grid_mapping_string = self._get_grid_mapping(zeroth_data_var)
                 A.meta['grid_mapping'] = grid_mapping_string
                 # XXX: can't add list or tuple as values to metadata dictionary...
                 dim_coord_names = self._get_dim_coord_names(data_var_names[0])
@@ -577,7 +582,7 @@ class TileDBWriter(_TDBWriter):
                                     attrs=attrs, ctx=self.ctx)
         tiledb.Array.create(array_filename, schema)
 
-    def create_domains(self, data_array_name='data'):
+    def create_domains(self, data_array_name='data', domains_mapping=None):
         """
         Create one TileDB domain for each unique shape / dimensions combination
         in the input Data Model. Each domain will contain:
@@ -588,7 +593,10 @@ class TileDBWriter(_TDBWriter):
 
         """
         self._make_shape_domains()
-        for domain_name, domain_var_names in self.domains_mapping.items():
+        if domains_mapping is None:
+            domains_mapping = self.domains_mapping
+
+        for domain_name, domain_var_names in domains_mapping.items():
             domain_coord_names = domain_name.split(self.domain_separator)
 
             # Create group.
@@ -621,7 +629,25 @@ class TileDBWriter(_TDBWriter):
         offset_point = other_data_model.variables[append_dim][:]
         return offset_point - base_point
 
+    def _get_scalar_offset(self, baseline, append_dim, self_dim_stop):
+        """
+        Use the specified baseline file to calcuate the single offset between every
+        successive step along the scalar append dimension.
+
+        """
+        odm = NCDataModel(baseline)
+        with odm.open_netcdf():
+            odm.classify_variables()
+            odm.get_metadata()
+            points = np.atleast_1d(odm.variables[append_dim][:])
+        return points - self_dim_stop
+
     def _get_scalar_points_and_offsets(self, others, append_dim, self_dim_stop):
+        """
+        Scan all of `others` to find each offset between the existing array and
+        each dataset to be appended.
+
+        """
         odp = []
         for other in others:
             ncdm = NCDataModel(other)
@@ -655,7 +681,7 @@ class TileDBWriter(_TDBWriter):
             tiledb.consolidate(array_path, ctx=ctx)
 
     def append(self, others, append_dim, data_array_name,
-               baseline=None, logfile=None, parallel=False,
+               baseline=None, group=False, logfile=None, parallel=False,
                verbose=False, consolidate=True):
         """
         Append extra data as described by the contents of `others` onto
@@ -664,6 +690,7 @@ class TileDBWriter(_TDBWriter):
         Notes:
           * extends one dimension only
           * cannot create new dimensions, only extend existing dimensions
+          * `others` must be str of one or more files to append, not NCDataModel
 
         TODO support multiple axis appends.
         TODO check if there's already data at the write inds and add an overwrite?
@@ -671,7 +698,7 @@ class TileDBWriter(_TDBWriter):
         """
         make_data_model = False
         # Check what sort of thing `others` is.
-        if isinstance(others, (NCDataModel, str)):
+        if isinstance(others, str):
             others = [others]
 
         # Check all domains for including the append dimension.
@@ -689,11 +716,12 @@ class TileDBWriter(_TDBWriter):
                 raise ValueError('Cannot determine scalar step without a baseline dataset.')
             self_ind_stop = 0
             self_dim_stop = self_dim_points[0]
-            offsets = self._get_scalar_points_and_offsets(others, append_dim, self_dim_stop)
+            offsets = self._get_scalar_offset(baseline, append_dim, self_dim_stop)
+            # offsets = self._get_scalar_points_and_offsets(others, append_dim, self_dim_stop)
             if len(offsets) == 1:
                 self_step = offsets[0]
             else:
-                # Smooth out any noise in slightly different offsets.
+                # Smooth out any noise in slightly different offsets.
                 self_step = np.median(np.diff(offsets))
             scalar = True
         else:
@@ -703,15 +731,27 @@ class TileDBWriter(_TDBWriter):
             offsets = None
             scalar = False
 
+        # Set up logging.
+        if logfile is not None:
+            logging.basicConfig(filename=job_args.logfile,
+                                level=logging.ERROR,
+                                format='%(asctime)s %(message)s',
+                                datefmt='%d/%m/%Y %H:%M:%S')
+
         # For multidim / multi-attr appends this may be more complex.
         n_jobs = len(others)
         # Prepare for serialization.
         tdb_config = self.ctx.config().dict() if self.ctx is not None else None
         all_job_args = []
         for ct, other in enumerate(others):
-            offset = offsets[ct] if offsets is not None else None
+            if offsets is None:
+                offset = None
+            elif len(offsets) == 1:
+                offset, = offsets
+            else:
+                offset = offsets[ct]
             this_job_args = AppendArgs(other=other, domain=domain_paths, name=data_array_name,
-                                       dim=append_dim, axis=append_axes, scalar=scalar,
+                                       dim=append_dim, axis=append_axes, scalar=scalar, group=group,
                                        offset=offset, mapping=self.domains_mapping, logfile=logfile,
                                        ind_stop=self_ind_stop, dim_stop=self_dim_stop, step=self_step,
                                        verbose=verbose, job_number=ct, n_jobs=n_jobs, ctx=tdb_config)
@@ -880,18 +920,30 @@ def write_array(array_filename, data_var,
 def write_multiattr_array(array_filename, data_vars,
                           start_index=None, scalar=False, ctx=None):
     """Write to each attr in the array."""
+    # Determine shape of items to be written.
+    zeroth_key = list(data_vars.keys())[0]
+    shape = data_vars[zeroth_key].shape  # All data vars *must* have the same shape for writing...
+    if scalar:
+        shape = (1,) + shape
+
+    # Get write indices.
     if start_index is None:
         start_index = 0
-        shape = data_vars[0].shape  # All data vars *must* have the same shape for writing...
-        if scalar:
-            shape = (1,) + shape
         write_indices = _array_indices(shape, start_index)
     else:
         write_indices = start_index
 
+    # Check for attrs with no data.
+    for name, data_var in data_vars.items():
+        if data_var is None:
+            # Handle missing data for this attr.
+            missing_data = np.empty(shape)
+            missing_data.fill(np.nan)
+            data_vars[name] = missing_data
+
     # Write netcdf data var contents into array.
     with tiledb.open(array_filename, 'w', ctx=ctx) as A:
-        A[write_indices] = {data_var.name: data_var[...] for data_var in data_vars}
+        A[write_indices] = {name: data_var[...] for name, data_var in data_vars.items()}
 
 
 def _dim_inds(dim_points, spatial_inds, offset=0):
@@ -901,6 +953,10 @@ def _dim_inds(dim_points, spatial_inds, offset=0):
 
 def _dim_points(points):
     """Convert a dimension variable (coordinate) points to index space."""
+    points_ndim = points.ndim
+    if points_ndim != 0:
+        emsg = f"The append dimension must be 1D, got {points_ndim}D array."
+        raise ValueError(emsg)
     start, stop = points[0], points[-1]
     step, = np.unique(np.diff(points))
     return start, stop, step
@@ -949,8 +1005,22 @@ def _make_multiattr_tile(other_data_model, domain_path, data_array_name,
                          self_ind_stop, self_dim_stop, self_step,
                          scalar_offset=None, do_logging=False, ctx=None):
     """Process appending a single tile to `self`, per domain."""
-    other_data_vars = [other_data_model.variables[var_name] for var_name in var_names]
-    data_var_shape  = other_data_vars[0].shape
+    other_data_vars = {}
+    for hashed_name in var_names:
+        result = other_data_model.data_vars_mapping.get(hashed_name, None)
+        if result is not None:
+            other_data_vars[hashed_name] = other_data_model.variables[hashed_name]
+        else:
+#             other_data_vars[hashed_name] = None
+            raise ValueError(f"No data var {hashed_name!r}!")
+
+    # Raise an error if no match in data vars between existing array and other_data_model.
+    if len(list(other_data_vars.keys())) == 0:
+        emsg = "Variable names in data model [{}] not present in existing array."
+        raise KeyError(emsg.format(', '.join(other_data_model.data_var_names)))
+
+    zeroth_data_var = list(other_data_vars.keys())[0]
+    data_var_shape  = other_data_vars[zeroth_data_var].shape
     other_dim_var = other_data_model.variables[append_dim]
     other_dim_points = np.atleast_1d(other_dim_var[:])
 
@@ -983,10 +1053,6 @@ def _make_multiattr_tile(other_data_model, domain_path, data_array_name,
     write_array(dim_array_path, other_dim_var,
                 start_index=offset_inds[append_axis], ctx=ctx)
 
-    dim_array_path = f"{domain_path}{append_dim}"
-    write_array(dim_array_path, other_dim_var,
-                start_index=offset_inds[append_axis], ctx=ctx)
-
 
 def _make_multiattr_tile_helper(serialized_job):
     """
@@ -1000,18 +1066,13 @@ def _make_multiattr_tile_helper(serialized_job):
     else:
         ctx = None
 
-    do_logging = False
-    if job_args.logfile is not None:
-        do_logging = True
-        logging.basicConfig(filename=job_args.logfile,
-                            level=logging.ERROR,
-                            format='%(asctime)s %(message)s',
-                            datefmt='%d/%m/%Y %H:%M:%S')
+    do_logging = job_args.logfile is not None
 
     domains_mapping = job_args.mapping
     domain_paths = job_args.domain
     append_dim = job_args.dim
     append_axes = job_args.axis
+    group = job_args.group
 
     # Record what we've processed...
     if do_logging:
@@ -1019,10 +1080,19 @@ def _make_multiattr_tile_helper(serialized_job):
 
     # To improve fault tolerance all the append processing happens in a try/except...
     try:
-        if isinstance(job_args.other, NCDataModel):
+        if group:
+            # Make an NCDataModelGroup from the list of paths in `other`.
+            odms = []
+            for fn in job_args.other:
+                odm = NCDataModel(fn)
+                odm.populate()
+                odms.append(odm)
+            other_data_model = NCDataModelGroup(odms)
+        elif isinstance(job_args.other, NCDataModel):
             other_data_model = job_args.other
         else:
             other_data_model = NCDataModel(job_args.other)
+            other_data_model.populate()
 
         with other_data_model.open_netcdf():
             for n, domain_path in enumerate(domain_paths):


### PR DESCRIPTION
A multi-attr TileDB array must be initiated with all the attrs in place. But if we're creating a new TileDB array with NetCDF files that contain only a single phenomenon, then we will only ever be able to create a single-attr TileDB array.

This PR introduces the core elements needed to remedy this, particularly via the new `NCDataModelGroup` data model, which meets the API spec of the `NCDataModel`, but introduces a mechanism to combine multiple `NCDataModel` instances into a single object. In this sense, the new class is not dissimilar to the NetCDF group concept, hence the name. There are also a few updates to `Writer`s to take full, but backward-compatible, advantage of the new data model functionality.

Not done here (to prevent this dragging on and on):

* [ ] proper inheritance between the data model classes
* [ ] hashed data variable names is probably not fully implemented (although the `missing_data_models` branch has some half-formed thoughts on this)
* [ ] domains are not calculated by `NCDataModelGroup`, so will not be calculated if you try and combine data models with multiple different dimensionalities
* [ ] combining multiple data models that contain more than one data variable each is not tested
* [ ] append offsets have broken again... 