### PR TITLE
Remove deprecated _TDBWriter class

### DIFF
--- a/nctotdb/tests/integration/append/test_basic_append.ipynb
+++ b/nctotdb/tests/integration/append/test_basic_append.ipynb
@@ -100,7 +100,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "writer.append([append_dataset], append_dim, data_array_name, verbose=False)"
+    "writer.append([append_dataset], append_dim, data_array_name, verbose=True)"
    ]
   },
   {
@@ -120,7 +120,19 @@
    "source": [
     "reader = nctotdb.TileDBReader(tiledb_name,\n",
     "                              array_filepath=array_filepath)\n",
-    "reader.to_iris()"
+    "result = reader.to_iris()\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "261853bf-ed06-4b72-8ab9-bbec20fc45c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "expected_shape = (4, 4, 3)\n",
+    "assert result.shape == expected_shape, \"Shapes do not match; append was unsuccessful.\""
    ]
   },
   {


### PR DESCRIPTION
Remove the largely unused `_TDBWriter` class and pull unduplicated functionality from that class into either the core `Writer` class, or the more fully featured `TileDBWriter` class.

There is still some outstanding near-duplicate functionality:
* `populate_array` and `populate_multiattr_array`
* `write_array` and `write_multiattr_array`

These are not handled further by these changes, but some further work could be undertaken to explore merging their functionality.